### PR TITLE
updated FAQ, support policy, removed mention of private preview

### DIFF
--- a/content/wasm-functions/faq.md
+++ b/content/wasm-functions/faq.md
@@ -16,7 +16,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/wasm-functions/faq
 
 ## Quota Limits
 
-> > Limits are subject to change as part of private preview. If you're interested in higher limits, please reach out to us [on Webex](https://wasm-functions.fermyon.app/join/webex) for assistance.
+> > Limits are subject to change as part of public preview. If you're interested in higher limits, please [contact us](https://www.fermyon.com/contact) for assistance.
 
 | All limits can be increased on request | Default Limit |
 | -------------------------------------- | ------------- |
@@ -64,10 +64,14 @@ To learn more about what feature support looks like for various programming lang
 ## Technical Frequently Asked Questions
 
 - **Q: Which regions is Fermyon Wasm Functions available in today?**
-  - In private preview, Fermyon Wasm Functions is available in US East, US West, and EU West.
+  - In public preview, Fermyon Wasm Functions is available in US East, US West, EU Central, and EU West.
+- **Q: How is user data structured in Fermyon Wasm Functions?**
+  - Each user has an associated account (created implicitly with `spin aka login`), which serves as the primary entity for managing their resources. An account is linked to zero or more Spin applications, allowing flexibility in how users develop and deploy their workloads.
+- **Q: How are Spin applications managed within a Fermyon Wasm Functions account?**
+  - Each Spin application belongs to a specific account and operates independently, ensuring modularity and security. Applications include metadata, dependencies, and deployment configurations, allowing for scalable and efficient management. If you have additional questions or need further clarification, please reach out to [support](./support.md).
 - **Q: How long does a login session last with Fermyon Wasm Functions? Will my Spin applications persist after I’ve been logged out?**
-  - Your login session (started by `spin aka login` is persisted until 30 days without activity. To learn more about the `spin aka` plugin, please visit the [developer documentation](/wasm-functions/aka-command-reference).
-- **Q: How do I get help during private preview?**
+  - Your login session (started by `spin aka login` is persisted until 30 days without activity. To learn more about the `spin aka` plugin, please visit the [reference documentation](/wasm-functions/aka-command-reference).
+- **Q: How do I get help with Fermyon Wasm Functions?**
   - We’re here to help! Checkout the [“How Do I get Help” page](/wasm-functions/support) in the developer documentation for next steps.
 
 ## Next Steps

--- a/content/wasm-functions/querying-linode-mysql.md
+++ b/content/wasm-functions/querying-linode-mysql.md
@@ -38,7 +38,7 @@ As we're going to use [TypeScript](https://www.typescriptlang.org/) to for build
 
 ### Configuring MySQL Database Server Access
 
-With a MySQL cluster deployed to your Linode account, you must explicitly allow inbound connections using either IPv6 or IPv4 addresses. For the sake of this tutorial and during private preview of _Fermyon Wasm Functions_, we'll use the `0.0.0.0/0` CIDR to allow inbound connectivity from any host to the MySQL database server. 
+With a MySQL cluster deployed to your Linode account, you must explicitly allow inbound connections using either IPv6 or IPv4 addresses. For the sake of this tutorial and during public preview of _Fermyon Wasm Functions_, we'll use the `0.0.0.0/0` CIDR to allow inbound connectivity from any host to the MySQL database server. 
 
 You can add the CIDR mentioned above, by browsing to the _Settings_ panel of your MySQL server and clicking the _Manage Access_ button. Once added the `0.0.0.0/0` CIDR and saving the changes, you should see the CIDR being explicitly listed on the settings panel, as shown here:
 

--- a/content/wasm-functions/quickstart.md
+++ b/content/wasm-functions/quickstart.md
@@ -17,7 +17,7 @@ url = "https://github.com/fermyon/developer/blob/main/content/wasm-functions/qui
 - [Success](#success)
 - [Next Steps](#next-steps)
 
-> This quickstart requires access to the private preview of Fermyon Wasm Functions. If you haven’t already requested access, please do so first by completing [this short form](https://fibsu0jcu2g.typeform.com/fwf-preview). The Fermyon team will review your request and follow up shortly.
+> This quickstart requires access to the public preview of Fermyon Wasm Functions. If you haven’t already requested access, please do so first by completing [this short form](https://fibsu0jcu2g.typeform.com/fwf-preview). The Fermyon team will review your request and follow up shortly.
 
 Fermyon Wasm Functions is the platform for running [Spin](/spin) applications inside of the Akamai Connected Cloud. For more details on limitations and support policy, check out the [FAQ](faq.md).
 

--- a/content/wasm-functions/supabase-cache-proxy.md
+++ b/content/wasm-functions/supabase-cache-proxy.md
@@ -347,7 +347,7 @@ Now that we have granted our component access to the `default` Key Value store, 
 - All data persisted in the cache should have an expiration timestamp taking the `cache_ttl` configuration data into context
 - Cache invalidation should happen whenever data is added, updated or removed from the cache
 
-> **A note on cache performance expectations:** Fermyon Wasm Functions' Key Value store does not currently support geo-replication in private preview. This means that cache performance may vary depending on where requests originate. While this works well for many use cases, some latency-sensitive applications may experience differences in response times. We welcome [feedback](https://fibsu0jcu2g.typeform.com/to/G2u4tPcP) on how this impacts your experience so we can improve the service in future releases.
+> **A note on cache performance expectations:** Fermyon Wasm Functions' Key Value store does not currently support geo-replication in public preview. This means that cache performance may vary depending on where requests originate. While this works well for many use cases, some latency-sensitive applications may experience differences in response times. We welcome [feedback](https://fibsu0jcu2g.typeform.com/to/G2u4tPcP) on how this impacts your experience so we can improve the service in future releases.
 
 We’ll use the `Kv` APIs provided by the Spin SDK tor interacting with the Key Value store. Place the following code in the new `src/cache.ts` file:
 

--- a/content/wasm-functions/support.md
+++ b/content/wasm-functions/support.md
@@ -9,10 +9,6 @@ keywords = "abuse security concern"
 
 #### We're Here To Help
 
-During private preview, support is provided on a best-effort basis. Here are the best ways to contact the Fermyon team:
+For assistance with issues, please reach out to customer support ([contact information and hours of operation here](https://www.fermyon.com/contact)). 
 
-* *For the fastest response:* Connect with us on Webex via our [Fermyon & Akamai Meeting Room](webexteams://im?space=3e625be0-b743-11ef-bf5d-bf326465b5e4)
-* *Email Us:* Reach out at [akamai@fermyon.com](mailto://akamai@fermyon.com)
-* *Join the conversation:* For community discussions about Spin and related topics, visit our [Fermyon Discord](https://discord.gg/AAFNfS7NGf)
-
-Looking ahead? Learn about support and training options for paid plans by visiting [akamai.fermyon.com/pricing](https://akamai.fermyon.com/#pricing). 
+Otherwise, the [Fermyon Discord](https://discord.gg/AAFNfS7NGf) is a great place to join in community discussions about Fermyon Wasm Functions and related topics. 


### PR DESCRIPTION
Resolves https://github.com/fermyon/a3000-docs/issues/205
Resolves https://github.com/fermyon/a3000-docs/issues/219
resolves https://github.com/fermyon/a3000-docs/issues/227

Also removes any language associated with private preview

Content must go through a pre-merge checklist.

## Pre-Merge Content Checklist

This documentation has been checked to ensure that:

- [ ] The `title, `template`, and `date` are all set
- [ ] File does not use CRLF, but uses plain LF (hint: use `cat -ve <filename> | grep '^M' | wc -l` and expect 0 as a result) 
- [ ] Has passed [`bart check`](https://bartholomew.fermyon.dev/quickstart)
- [ ] Has run `npm run build-index`
- [ ] Has been manually tested by running in Spin/Bartholomew (hint: use `PREVIEW_MODE=1` and run `npm run styles` to update styling)
- [ ] Headings are using Title Case
- [ ] Code blocks have the programming language set to properly highlight syntax and the proper copy directive
- [ ] Have tested with `npm run test` and resolved all errors
